### PR TITLE
Made code more maintanable

### DIFF
--- a/mandaw/gameobject.py
+++ b/mandaw/gameobject.py
@@ -19,8 +19,8 @@ class GameObject(pygame.Rect):
             pygame.draw.ellipse(self.window.window, self.color, self)
     
     def center(self):
-        self.x = self.window.width / 2 - self.width / 2
-        self.y = self.window.height / 2 - self.height / 2
+        self.center_x()
+        self.center_y()
     
     def center_x(self):
         self.x = self.window.width / 2 - self.width / 2


### PR DESCRIPTION
Instead of duplicating statements, the `center` method now uses `center_x` and `center_y`.